### PR TITLE
Blog app - integration specs for views and fix n+1 problems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,6 +61,8 @@ group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem 'web-console'
 
+  gem "bullet", "~> 7.0"
+
   # Add speed badges [https://github.com/MiniProfiler/rack-mini-profiler]
   # gem "rack-mini-profiler"
 
@@ -74,3 +76,7 @@ group :test do
   gem 'selenium-webdriver'
   gem 'webdrivers'
 end
+
+# gem "bullet", "~> 7.0"
+# gem "uniform_notifier"
+# gem "xmpp4r"

--- a/Gemfile
+++ b/Gemfile
@@ -62,7 +62,7 @@ group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem 'web-console'
 
-  gem "bullet", "~> 7.0"
+  gem 'bullet', '~> 7.0'
 
   # Add speed badges [https://github.com/MiniProfiler/rack-mini-profiler]
   # gem "rack-mini-profiler"

--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,7 @@ group :development, :test do
   gem 'debug', platforms: %i[mri mingw x64_mingw]
   gem 'rails-controller-testing'
   gem 'rspec-rails', '>= 3.9.0'
+  # gem 'rspec-html-matchers', '~> 0.10.0'
 end
 
 group :development do
@@ -73,6 +74,7 @@ end
 group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem 'capybara'
+  gem 'rspec-html-matchers'
   gem 'selenium-webdriver'
   gem 'webdrivers'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -176,11 +176,18 @@ GEM
     reline (0.3.1)
       io-console (~> 0.5)
     rexml (3.2.5)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
     rspec-core (3.12.0)
       rspec-support (~> 3.12.0)
     rspec-expectations (3.12.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
+    rspec-html-matchers (0.10.0)
+      nokogiri (~> 1)
+      rspec (>= 3.0.0.a)
     rspec-mocks (3.12.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
@@ -262,6 +269,7 @@ DEPENDENCIES
   puma (~> 5.0)
   rails (~> 7.0.4)
   rails-controller-testing
+  rspec-html-matchers
   rspec-rails (>= 3.9.0)
   rubocop (>= 1.0, < 2.0)
   selenium-webdriver

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,9 @@ GEM
     bootsnap (1.13.0)
       msgpack (~> 1.2)
     builder (3.2.4)
+    bullet (7.0.3)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     capybara (3.37.1)
       addressable
       matrix
@@ -227,6 +230,7 @@ GEM
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.3.0)
+    uniform_notifier (1.16.0)
     web-console (4.2.0)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -249,6 +253,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap
+  bullet (~> 7.0)
   capybara
   debug
   importmap-rails

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,12 +1,13 @@
 class PostsController < ApplicationController
   def index
     @user = User.find(params[:user_id])
-    @posts = User.find(params[:user_id]).posts
+    @posts = @user.posts.includes(comments: [:author])
   end
 
   def show
     @user = User.find(params[:user_id])
-    @post = Post.find(params[:id])
+    # @post = Post.find(params[:id])
+    @post = Post.includes(comments: [:author]).find(params[:id])
   end
 
   def new

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -27,14 +27,16 @@ main>
       </div>
 
       <% @user.last_three_post.each do |post| %>
-        <div class="user-post-preview">
+      <div class="user-post-preview">
+        <%= link_to user_post_path(@user, post) do%>
           <h3><%= post.title%></h3>
-          <p><%= post.text %></p>
-          <p class="post-data">
-            <span>Comments: <%= post.comments_counter %></span>
-            <span>Likes: <%= post.likes_counter %></span>
-          </p>
-        </div>
+        <% end %>            
+        <p><%= post.text %></p>
+        <p class="post-data">
+          <span>Comments: <%= post.comments_counter %></span>
+          <span>Likes: <%= post.likes_counter %></span>
+        </p>
+      </div>
       <% end %>
       <%= link_to user_posts_path(@user) do %>
         <div class="div-see-all">

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,6 +1,15 @@
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
+  config.after_initialize do
+    Bullet.enable        = true
+    Bullet.alert         = true
+    Bullet.bullet_logger = true
+    Bullet.console       = true
+    Bullet.rails_logger  = true
+    Bullet.add_footer    = true
+  end
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded any time

--- a/spec/integration/post_index_spec.rb
+++ b/spec/integration/post_index_spec.rb
@@ -1,0 +1,74 @@
+require 'rails_helper'
+
+RSpec.describe 'post#index', type: :feature do
+  include RSpecHtmlMatchers
+
+  before :each do
+    @first_user = User.create(name: 'Tom',
+                              photo: 'https://images.unsplash.com/photo-1508921912186-1d1a45ebb3c1?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=387&q=80',
+                              bio: 'Teacher from Mexico.')
+
+    @first_post = Post.create(author: @first_user, title: 'My presentation', text: 'This is my first post')
+    @second_post = Post.create(author: @first_user, title: 'Hello again', text: 'This is my second post. Welcome')
+
+    @first_comment = Comment.create(post: @first_post, author: @first_user, text: 'Hi Tom!')
+    @second_comment = Comment.create(post: @first_post, author: @first_user, text: 'Interesting')
+  end
+
+  describe 'post index page' do
+    # I can see the user's profile picture.
+    it 'shows users profile picture' do
+      visit "/users/#{@first_user.id}/posts"
+      expect(page).to have_tag('img', src: @first_user.photo)
+    end
+    # I can see the user's username.
+    it 'shows users username' do
+      visit "/users/#{@first_user.id}/posts"
+      expect(page).to have_content(@first_user.name)
+    end
+    # I can see the number of posts the user has written.
+    it 'shows the number of posts' do
+      visit "/users/#{@first_user.id}/posts"
+      expect(page).to have_content("Number of posts: #{@first_user.posts_counter}")
+    end
+    # I can see a post's title.
+    it 'shows a post title' do
+      visit "/users/#{@first_user.id}/posts"
+      expect(page).to have_tag('h3', @first_post.title)
+      expect(page).to have_tag('h3', @second_post.title)
+    end
+    # I can see some of the post's body.
+    it 'shows some of the post body' do
+      visit "/users/#{@first_user.id}/posts"
+      expect(page).to have_tag('p', @first_post.text)
+    end
+    # I can see the first comments on a post.
+    it 'shows the firsts comments on a post' do
+      visit "/users/#{@first_user.id}/posts"
+      expect(page).to have_tag('div', with: { class: 'post-comments-preview' }) do
+        with_tag 'p', count: 2
+      end
+    end
+    # I can see how many comments a post has.
+    it 'shows the number of posts' do
+      visit "/users/#{@first_user.id}/posts"
+      expect(page).to have_content("Comments: #{@first_post.comments_counter}")
+    end
+    # I can see how many likes a post has.
+    it 'shows the number of posts' do
+      visit "/users/#{@first_user.id}/posts"
+      expect(page).to have_content("Likes: #{@first_post.likes_counter}")
+    end
+    # I can see a section for pagination if there are more posts than fit on the view.
+    it 'shows pagination' do
+      visit "/users/#{@first_user.id}/posts"
+      expect(page).to have_content('Pagination')
+    end
+    # When I click on a post, it redirects me to that post's show page.
+    it 'redirects to post show page when cliked' do
+      visit "/users/#{@first_user.id}/posts"
+      click_on(@first_post.title)
+      expect(page).to have_current_path(user_post_path(@first_user.id, @first_post.id))
+    end
+  end
+end

--- a/spec/integration/post_show_spec.rb
+++ b/spec/integration/post_show_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe 'post#show', type: :feature do
+  include RSpecHtmlMatchers
+
+  before :each do
+    @first_user = User.create(name: 'Tom',
+                              photo: 'https://images.unsplash.com/photo-1508921912186-1d1a45ebb3c1?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=387&q=80',
+                              bio: 'Teacher from Mexico.')
+
+    @first_post = Post.create(author: @first_user, title: 'My presentation', text: 'This is my first post')
+    @second_post = Post.create(author: @first_user, title: 'Hello again', text: 'This is my second post. Welcome')
+
+    @first_comment = Comment.create(post: @first_post, author: @first_user, text: 'Hi Tom!')
+    @second_comment = Comment.create(post: @first_post, author: @first_user, text: 'Interesting')
+  end
+
+  describe 'post show page' do
+    # I can see the post's title.
+    it 'shows a post title' do
+      visit "/users/#{@first_user.id}/posts/#{@first_post.id}"
+      expect(page).to have_content(@first_post.title)
+    end
+    # I can see who wrote the post.
+    it 'shows the author' do
+      visit "/users/#{@first_user.id}/posts/#{@first_post.id}"
+      expect(page).to have_content(@first_user.name)
+    end
+    # I can see how many comments it has.
+    it 'shows the number of posts' do
+      visit "/users/#{@first_user.id}/posts/#{@first_post.id}"
+      expect(page).to have_content("Comments: #{@first_post.comments_counter}")
+    end
+    # I can see how many likes it has.
+    it 'shows the number of likes' do
+      visit "/users/#{@first_user.id}/posts/#{@first_post.id}"
+      expect(page).to have_content("Likes: #{@first_post.likes_counter}")
+    end
+    # I can see the post body.
+    it 'shows the post body' do
+      visit "/users/#{@first_user.id}/posts/#{@first_post.id}"
+      expect(page).to have_tag('p', @first_post.text)
+    end
+    # I can see the username of each commentor. // I can see the comment each commentor left.
+    it 'shows the username of each commentor and the comment' do
+      visit "/users/#{@first_user.id}/posts/#{@first_post.id}"
+      expect(page).to have_tag('div', with: { class: 'post-comments-preview' }) do
+        with_tag 'p', text: "#{@first_comment.author.name}: #{@first_comment.text}"
+      end
+    end
+  end
+end

--- a/spec/integration/user_index_spec.rb
+++ b/spec/integration/user_index_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe 'user#index', type: :feature do
+  include RSpecHtmlMatchers
+
+  before :each do
+    @first_user = User.create(name: 'Tom',
+                              photo: 'https://images.unsplash.com/photo-1508921912186-1d1a45ebb3c1?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=387&q=80',
+                              bio: 'Teacher from Mexico.')
+
+    @first_post = Post.create(author: @first_user, title: 'Hello', text: 'This is my first post')
+    @second_post = Post.create(author: @first_user, title: 'Hello again', text: 'This is my second post. Welcome')
+
+    @first_comment = Comment.create(post: @first_post, author: @first_user, text: 'Hi Tom!')
+    @second_comment = Comment.create(post: @first_post, author: @first_user, text: 'Interesting')
+  end
+
+  describe 'user index page' do
+    # I can see the username of all other users.
+    it 'shows the user name of all users' do
+      visit '/'
+      expect(page).to have_content(@first_user.name)
+    end
+
+    # I can see the profile picture for each user.
+    it 'shows profile picture for each user' do
+      visit '/'
+      expect(page).to have_tag('img', src: @first_user.photo)
+    end
+
+    # I can see the number of posts each user has written.
+    it 'shows the number of post for each user' do
+      visit '/'
+      expect(page).to have_content(@first_user.posts_counter)
+    end
+
+    # When I click on a user, I am redirected to that user's show page.
+    it 'redirects to user show page when cliked' do
+      visit '/'
+      click_on(@first_user.name)
+      expect(page).to have_current_path(user_path(@first_user.id))
+    end
+  end
+end

--- a/spec/integration/user_show_spec.rb
+++ b/spec/integration/user_show_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe 'user#show', type: :feature do
     end
 
     # When I click a user's post, it redirects me to that post's show page.
-    it 'redirects to user show page when cliked' do
+    it 'redirects to post show page when cliked' do
       visit "/users/#{@first_user.id}"
       click_on(@first_post.title)
       expect(page).to have_current_path(user_post_path(@first_user.id, @first_post.id))
@@ -55,8 +55,8 @@ RSpec.describe 'user#show', type: :feature do
     # When I click to see all posts, it redirects me to the user's post's index page.
     it 'redirects to user posts index when cliked' do
       visit "/users/#{@first_user.id}"
-      click_button('See all posts')
-      expect(page).to have_current_path("/users/#{@first_user.id}")
+      click_link('See all posts')
+      expect(page).to have_current_path("/users/#{@first_user.id}/posts")
     end
   end
 end

--- a/spec/integration/user_show_spec.rb
+++ b/spec/integration/user_show_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+RSpec.describe 'user#show', type: :feature do
+  include RSpecHtmlMatchers
+
+  before :each do
+    @first_user = User.create(name: 'Tom',
+                              photo: 'https://images.unsplash.com/photo-1508921912186-1d1a45ebb3c1?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=387&q=80',
+                              bio: 'Teacher from Mexico.')
+
+    @first_post = Post.create(author: @first_user, title: 'Hello', text: 'This is my first post')
+    @second_post = Post.create(author: @first_user, title: 'Hello again', text: 'This is my second post. Welcome')
+    @third_post = Post.create(author: @first_user, title: 'Hi', text: 'Whats up folks?')
+
+    @first_comment = Comment.create(post: @first_post, author: @first_user, text: 'Hi Tom!')
+    @second_comment = Comment.create(post: @first_post, author: @first_user, text: 'Interesting')
+  end
+
+  describe 'user index page' do
+    # I can see the user's profile picture, username and number of posts.
+    it 'shows users profile picture' do
+      visit "/users/#{@first_user.id}"
+      expect(page).to have_tag('img', src: @first_user.photo)
+      expect(page).to have_content(@first_user.name)
+      expect(page).to have_content("Number of posts: #{@first_user.posts_counter}")
+    end
+
+    # I can see the user's bio.
+    it 'shows users bio' do
+      visit "/users/#{@first_user.id}"
+      expect(page).to have_content(@first_user.bio)
+    end
+
+    # I can see the user's first 3 posts.
+    it 'shows users first 3 posts' do
+      visit "/users/#{@first_user.id}"
+      expect(page).to have_tag('section') do
+        with_tag 'div', with: { class: 'user-post-preview' }, count: 3
+      end
+    end
+
+    # I can see a button that lets me view all of a user's posts.
+    it 'shows a button to all posts' do
+      visit "/users/#{@first_user.id}"
+      expect(page).to have_tag('button', text: 'See all posts')
+    end
+
+    # When I click a user's post, it redirects me to that post's show page.
+    it 'redirects to user show page when cliked' do
+      visit "/users/#{@first_user.id}"
+      click_on(@first_post.title)
+      expect(page).to have_current_path(user_post_path(@first_user.id, @first_post.id))
+    end
+
+    # When I click to see all posts, it redirects me to the user's post's index page.
+    it 'redirects to user posts index when cliked' do
+      visit "/users/#{@first_user.id}"
+      click_button('See all posts')
+      expect(page).to have_current_path("/users/#{@first_user.id}")
+    end
+  end
+end


### PR DESCRIPTION
## Project Requirements 🎯 🎯 
#### n+1
- [x] Make sure that the N+1 problem is solved when fetching all posts and their comments for a user. This is the corresponding wireframe view: ![blog all user posts](../images/blog_user_all_posts.png)

#### Integration specs
-  [x] Use Capybara to write integration tests for each view in your project.
  
- [x] User index page:
  - I can see the username of all other users.
  - I can see the profile picture for each user.
  - I can see the number of posts each user has written.
  - When I click on a user, I am redirected to that user's show page.
  
- [x] user show page:
  - I can see the user's profile picture.
  - I can see the user's username.
  - I can see the number of posts the user has written.
  - I can see the user's bio.
  - I can see the user's first 3 posts.
  - I can see a button that lets me view all of a user's posts.
  - When I click a user's post, it redirects me to that post's show page.
  - When I click to see all posts, it redirects me to the user's post's index page.

- [x] User post index page:
  - I can see the user's profile picture.
  - I can see the user's username.
  - I can see the number of posts the user has written.
  - I can see a post's title.
  - I can see some of the post's body.
  - I can see the first comments on a post.
  - I can see how many comments a post has.
  - I can see how many likes a post has.
  - I can see a section for pagination if there are more posts than fit on the view.
  - When I click on a post, it redirects me to that post's show page.

- [x] Post show page:
  - I can see the post's title.
  - I can see who wrote the post.
  - I can see how many comments it has.
  - I can see how many likes it has.
  - I can see the post body.
  - I can see the username of each commentor.
  - I can see the comment each commentor left.